### PR TITLE
Add timestamp to saved png file name

### DIFF
--- a/piano-visualizer.js
+++ b/piano-visualizer.js
@@ -221,7 +221,17 @@ function truncateString(str, maxLength = 40) {
 function mouseClicked() {
   // Save the canvas content as an image file
   if (mouseX < 50 && mouseY < 50) {
-    saveCanvas('nicechord-pianometer', 'png');
+    const now = new Date();
+    const strDate =
+      now.getFullYear() +
+      String(now.getMonth()+1).padStart(2, '0') +
+      String(now.getDate()).padStart(2, '0');
+    const strTime =
+      String(now.getHours()).padStart(2, '0') +
+      String(now.getMinutes()).padStart(2, '0') +
+      String(now.getSeconds()).padStart(2, '0');
+    const fileName = `nicechord-pianometer-${strDate}_${strTime}`;
+    saveCanvas(fileName, 'png');
   }
   if (mouseY > 76) {
     if (mouseX <= 84) {


### PR DESCRIPTION
This changes the saved png file name to `nicechord-pianometer-{DATE}_{TIME}` (e.g.  `nicechord-pianometer-20230408_114211.png`) so that users don't need to worry about conflicted file names.

A demo of this version can be found [here](https://pianometer.nc.sup39.dev/).