### PR TITLE
feat: add velocity meter display for piano keys

### DIFF
--- a/globals.js
+++ b/globals.js
@@ -38,6 +38,15 @@ let totalIntensityScore = 0;
 let notePressedCount = 0;
 let notePressedCountHistory = [];
 
+// 音量相關的全域變數
+let velocities = new Array(128).fill(0); // 儲存每個音符的當前音量
+let velocityDecayRate = 0.98; // 調整衰減速率
+let maxVelocityHeight = 40; // 調整最大高度
+let peakVelocities = new Array(128).fill(0); // 儲存每個音符的最大音量
+let peakHoldTime = new Array(128).fill(0); // 儲存最大音量的持續時間
+const PEAK_HOLD_FRAMES = 180; // 3 秒 = 60 幀/秒 × 3 秒
+let displayVelocity = false; // 改為預設關閉
+
 WebMidi.enable(function (err) { //check if WebMidi.js is enabled
     if (err) {
         console.log("WebMidi could not be enabled.", err);
@@ -91,11 +100,15 @@ function noteOn(pitch, velocity) {
     totalNotesPlayed++;
     notesThisFrame++;
     totalIntensityScore += velocity;
+
+    // 更新按鍵音量和最大音量線
+    velocities[pitch] = velocity;
+    peakVelocities[pitch] = velocity;
+    peakHoldTime[pitch] = PEAK_HOLD_FRAMES;
     
-    // piano visualizer
     isKeyOn[pitch] = 1;
     if (nowPedaling) {
-      isPedaled[pitch] = 1;
+        isPedaled[pitch] = 1;
     }
 }
 
@@ -146,4 +159,8 @@ function changeColor() {
     darkenedColor = keyOnColor.levels.map(x => floor(x * .7));
     pedaledColor = color(`rgb(${darkenedColor[0]}, ${darkenedColor[1]}, ${darkenedColor[2]})`)
     console.log(pedaledColor.levels);
+}
+
+function toggleDisplayVelocity(cb) {
+    displayVelocity = cb.checked;
 }

--- a/index.html
+++ b/index.html
@@ -42,6 +42,13 @@
                                 <span class="switch-txt" turnOn="On" turnOff="Off"></span>
                             </label>
                         </div>
+                        <div style="display: flex; align-items: center;">
+                            <span style="margin-right: 5px;">顯示音量</span>
+                            <input type="checkbox" id="display-velocity-checkbox" onclick="toggleDisplayVelocity(this)">
+                            <label for="display-velocity-checkbox">
+                                <span class="switch-txt" turnOn="On" turnOff="Off"></span>
+                            </label>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -553,7 +553,8 @@ input[type=checkbox] {
 }
 
 label[for=rainbow-mode-checkbox],
-label[for=display-note-names-checkbox] {
+label[for=display-note-names-checkbox],
+label[for=display-velocity-checkbox] {
     cursor: pointer;
     width: 50px;
     height: 25px;
@@ -565,7 +566,8 @@ label[for=display-note-names-checkbox] {
 }
 
 label[for=rainbow-mode-checkbox]:after,
-label[for=display-note-names-checkbox]:after {
+label[for=display-note-names-checkbox]:after,
+label[for=display-velocity-checkbox]:after {
     content: '';
     position: absolute;
     top: 1.25px;
@@ -578,17 +580,20 @@ label[for=display-note-names-checkbox]:after {
 }
 
 input:checked + label[for=rainbow-mode-checkbox],
-input:checked + label[for=display-note-names-checkbox] {
+input:checked + label[for=display-note-names-checkbox],
+input:checked + label[for=display-velocity-checkbox] {
     background: #6f42c1;
 }
 
 label[for=rainbow-mode-checkbox]:active:after,
-label[for=display-note-names-checkbox]:active:after {
+label[for=display-note-names-checkbox]:active:after,
+label[for=display-velocity-checkbox]:active:after {
     width: 32.5px;
 }
 
 input:checked + label[for=rainbow-mode-checkbox]:after,
-input:checked + label[for=display-note-names-checkbox]:after {
+input:checked + label[for=display-note-names-checkbox]:after,
+input:checked + label[for=display-velocity-checkbox]:after {
     left: calc(100% - 1.25px);
     transform: translateX(-100%);
 }


### PR DESCRIPTION
The velocity meter provides visual feedback for key press intensity, helping users understand their playing dynamics. Bars use scale marks for better readability, and peak indicators help track maximum velocity for each note.

Demo: https://vimeo.com/1026831004